### PR TITLE
Devops/et 772 releases fix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,7 @@ inputs:
     description: 'Comma-separated list of modules to include in release repostitories'
     required: true
     type: string
+    default: 'none'
   acr:
     description: 'IQGeos Azure container registry server name'
     required: true

--- a/action.yml
+++ b/action.yml
@@ -159,8 +159,6 @@ runs:
           NEW_TAGS: ${{ inputs.updated_tags }}
           ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
 
-
-
       - name: Retag Multi-Arch image for ACR releases
         shell: bash
         if: ${{ inputs.is_release == 'true' && contains(inputs.release_modules, inputs.module) }}

--- a/action.yml
+++ b/action.yml
@@ -22,8 +22,9 @@ inputs:
     description: 'Module to build (product, devdb, editions)'
     required: true
     type: string 
-  main_module:
-    description: 'Whether this module is the main module (product) or a supporting module (devdb, editions)'
+  release_modules:
+    description: 'Comma-separated list of modules to include in release repostitories'
+    required: true
     type: string
   acr:
     description: 'IQGeos Azure container registry server name'
@@ -158,9 +159,11 @@ runs:
           NEW_TAGS: ${{ inputs.updated_tags }}
           ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
 
+
+
       - name: Retag Multi-Arch image for ACR releases
         shell: bash
-        if: ${{ inputs.is_release == 'true' && inputs.main_module == inputs.module }}
+        if: ${{ inputs.is_release == 'true' && contains(inputs.release_modules, inputs.module) }}
         run: |
           IFS=',' read -ra TAGS <<< $NEW_TAGS 
           SOURCE_IMAGE=$ACR/$ENGINEERING_PREFIX/$MODULE:$VERSION
@@ -180,7 +183,7 @@ runs:
       - name: Retag Multi-Arch image for Harbor releases
         shell: bash
         continue-on-error: true        
-        if: ${{ inputs.is_release == 'true' && inputs.main_module == inputs.module }}
+        if: ${{ inputs.is_release == 'true' && contains(inputs.release_modules, inputs.module) }}
         run: |
           IFS=',' read -ra TAGS <<< $NEW_TAGS 
           SOURCE_IMAGE=$ACR/$ENGINEERING_PREFIX/$MODULE:$VERSION

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
     description: 'Module to build (product, devdb, editions)'
     required: true
     type: string 
+  main_module:
+    description: 'Whether this module is the main module (product) or a supporting module (devdb, editions)'
+    type: string
   acr:
     description: 'IQGeos Azure container registry server name'
     required: true
@@ -56,9 +59,6 @@ inputs:
     default: devops_sandbox_releases
   is_release:
     description: 'Whether this is a pre-release or release version'
-    type: string
-  main_module:
-    description: 'Whether this module is the main module (product) or a supporting module (devdb, editions)'
     type: string
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,9 @@ inputs:
   is_release:
     description: 'Whether this is a pre-release or release version'
     type: string
+  main_module:
+    description: 'Whether this module is the main module (product) or a supporting module (devdb, editions)'
+    type: string
 
 runs:
     using: "composite"
@@ -157,7 +160,7 @@ runs:
 
       - name: Retag Multi-Arch image for ACR releases
         shell: bash
-        if: ${{ inputs.is_release == 'true' }}
+        if: ${{ inputs.is_release == 'true' && inputs.main_module == inputs.module }}
         run: |
           IFS=',' read -ra TAGS <<< $NEW_TAGS 
           SOURCE_IMAGE=$ACR/$ENGINEERING_PREFIX/$MODULE:$VERSION
@@ -177,7 +180,7 @@ runs:
       - name: Retag Multi-Arch image for Harbor releases
         shell: bash
         continue-on-error: true        
-        if: ${{ inputs.is_release == 'true' }}
+        if: ${{ inputs.is_release == 'true' && inputs.main_module == inputs.module }}
         run: |
           IFS=',' read -ra TAGS <<< $NEW_TAGS 
           SOURCE_IMAGE=$ACR/$ENGINEERING_PREFIX/$MODULE:$VERSION


### PR DESCRIPTION
Added release_modules input and left as required since the previous build-multi-arch-workflow always gets the default value of at least 'none' so there will always be an input passed here, either the default value or the overwritten value passed in from the main module workflow. Then for the retagging to releases_ in ACR and Harbor, logic was added to check if the module being retagged is in the list of release_modules, otherwise the retagging for releases_ is skipped. 

Successful test run using a .final tag where workflow_manager was pushed to releases (that's the only one I set in the main build-workflow-manager workflow) but all other injectors and platform-with-workflow-manager were not pushed to releases_ in ACR and Harbor: https://github.com/IQGeo/myworld-product-workflow-manager/actions/runs/19947382314
(I used the devops_sandbox_engineering and devops_sandbox_releases image repositories so that nothing during development was pushed to actual releases folders.)