### PR TITLE
ET-772: release_modules: input with default should not be required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,9 +24,9 @@ inputs:
     type: string 
   release_modules:
     description: 'Comma-separated list of modules to include in release repostitories'
-    required: true
+    required: false
     type: string
-    default: 'none'
+    default: ''  # An empty string means no modules are included in release repositories
   acr:
     description: 'IQGeos Azure container registry server name'
     required: true


### PR DESCRIPTION
When an input has a default, it should not be required.

In this case, we had the correct behavior in build-modules-workflow, but build-multi-arch-workflow and build-multi-arch-action both had required: true.

The Platform and SaaS workflows don't make use of build-modules-workflow

While making the required adjustment, I also found I would prefer if defaults are representative of their expected data; in this case an empty comma separated list.

I added some mock tests for the condition logic: https://github.com/IQGeo/editions-telecom/actions/workflows/dummy-workflow.yml