### PR TITLE
ET-979: qa: add sbom/attestation steps

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,16 +89,15 @@ runs:
         uses: docker/setup-buildx-action@v3
         
       - name: Create Version manifest and push to Azure ACR
+        id: manifest
         shell: bash
         run: |
-            docker manifest create $ACR/$ENGINEERING_PREFIX/$MODULE:$VERSION \
-                $ACR/$ENGINEERING_PREFIX/$MODULE:$AMD_TAG \
-                $ACR/$ENGINEERING_PREFIX/$MODULE:$ARM_TAG
-            docker manifest annotate $ACR/$ENGINEERING_PREFIX/$MODULE:$VERSION \
-                $ACR/$ENGINEERING_PREFIX/$MODULE:$AMD_TAG --os linux --arch amd64
-            docker manifest annotate $ACR/$ENGINEERING_PREFIX/$MODULE:$VERSION \
-                $ACR/$ENGINEERING_PREFIX/$MODULE:$ARM_TAG --os linux --arch arm64
-            docker manifest push $ACR/$ENGINEERING_PREFIX/$MODULE:$VERSION
+            docker buildx imagetools create \
+              --tag $ACR/$ENGINEERING_PREFIX/$MODULE:$VERSION \
+              $ACR/$ENGINEERING_PREFIX/$MODULE:$AMD_TAG \
+              $ACR/$ENGINEERING_PREFIX/$MODULE:$ARM_TAG
+            DIGEST=$(docker buildx imagetools inspect $ACR/$ENGINEERING_PREFIX/$MODULE:$VERSION --format '{{json .Manifest}}' | jq -r '.digest')
+            echo "digest=$DIGEST" >> $GITHUB_OUTPUT
         env:
           VERSION: ${{ inputs.version }}
           AMD_TAG: ${{ inputs.amd_tag }}
@@ -107,6 +106,13 @@ runs:
           ACR: ${{ inputs.acr }}
           HARBOR: ${{ inputs.harbor }}
           ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
+
+      - name: Attest multi-arch manifest provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ inputs.acr }}/${{ inputs.engineering_prefix }}/${{ inputs.module }}
+          subject-digest: ${{ steps.manifest.outputs.digest }}
+          push-to-registry: true
 
       - name: Push to Harbor Engineering          
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -110,6 +110,34 @@ runs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3
 
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Generate SBOM from multi-arch manifest
+        shell: bash
+        env:
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+          ACR: ${{ inputs.acr }}
+          ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
+          MODULE: ${{ inputs.module }}
+        run: |
+          syft "registry:${ACR}/${ENGINEERING_PREFIX}/${MODULE}@${DIGEST}" \
+            --output spdx-json \
+            > /tmp/sbom.spdx.json
+
+      - name: Attach SBOM attestation to multi-arch manifest
+        shell: bash
+        env:
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+          ACR: ${{ inputs.acr }}
+          ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
+          MODULE: ${{ inputs.module }}
+        run: |
+          cosign attest --yes \
+            --predicate /tmp/sbom.spdx.json \
+            --type spdxjson \
+            "${ACR}/${ENGINEERING_PREFIX}/${MODULE}@${DIGEST}"
+
       - name: Sign multi-arch manifest with cosign keyless
         shell: bash
         env:

--- a/action.yml
+++ b/action.yml
@@ -107,12 +107,19 @@ runs:
           HARBOR: ${{ inputs.harbor }}
           ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
 
-      - name: Attest multi-arch manifest provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ${{ inputs.acr }}/${{ inputs.engineering_prefix }}/${{ inputs.module }}
-          subject-digest: ${{ steps.manifest.outputs.digest }}
-          push-to-registry: true
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign multi-arch manifest with cosign keyless
+        shell: bash
+        env:
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+          ACR: ${{ inputs.acr }}
+          ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
+          MODULE: ${{ inputs.module }}
+        run: |
+          cosign sign --yes \
+            "${ACR}/${ENGINEERING_PREFIX}/${MODULE}@${DIGEST}"
 
       - name: Push to Harbor Engineering          
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -110,34 +110,6 @@ runs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3
 
-      - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0
-
-      - name: Generate SBOM from multi-arch manifest
-        shell: bash
-        env:
-          DIGEST: ${{ steps.manifest.outputs.digest }}
-          ACR: ${{ inputs.acr }}
-          ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
-          MODULE: ${{ inputs.module }}
-        run: |
-          syft "registry:${ACR}/${ENGINEERING_PREFIX}/${MODULE}@${DIGEST}" \
-            --output spdx-json \
-            > /tmp/sbom.spdx.json
-
-      - name: Attach SBOM attestation to multi-arch manifest
-        shell: bash
-        env:
-          DIGEST: ${{ steps.manifest.outputs.digest }}
-          ACR: ${{ inputs.acr }}
-          ENGINEERING_PREFIX: ${{ inputs.engineering_prefix }}
-          MODULE: ${{ inputs.module }}
-        run: |
-          cosign attest --yes \
-            --predicate /tmp/sbom.spdx.json \
-            --type spdxjson \
-            "${ACR}/${ENGINEERING_PREFIX}/${MODULE}@${DIGEST}"
-
       - name: Sign multi-arch manifest with cosign keyless
         shell: bash
         env:


### PR DESCRIPTION
Successful run:

https://github.com/IQGeo/product-network-manager-electric/actions/runs/29825322298

Updated workflow with manifest/sbom step. 
Confirmed that they are present and added results to the ET-979 jira ticket. 

Related PR's:

https://github.com/IQGeo/devops-engineering-ci-public-build-module-workflow/pull/15
https://github.com/IQGeo/devops-engineering-ci-public-build-push-action/pull/10